### PR TITLE
Sublime fix for inline google translate err service not avaible try again or use rpoxy

### DIFF
--- a/start_master
+++ b/start_master
@@ -1,1 +1,0 @@
-start_master

--- a/start_master
+++ b/start_master
@@ -1,0 +1,1 @@
+start_master


### PR DESCRIPTION
Update Google API url and result data processing #1

The provided google url no longer works by now. Found an acceptable solution here:
https://ctrlq.org/code/19909-google-translate-api

you can make a call to the secret translate.googleapis.com API that is internally used by the Google Translate extension for Chrome and requires no authentication.
Also have to adjust the result data processing for the new api.

Anyway, thanks for this good sublime text package.

Well your file location may differ from mine but I just overwrote the file here:
%appdata% ...\Roaming\Sublime Text 3\Packages\Inline Google Translate\core\translate.py

Worked for me!